### PR TITLE
Get away from master and slave language

### DIFF
--- a/pi_fly/go.py
+++ b/pi_fly/go.py
@@ -27,7 +27,7 @@ class OneWireTemperatureDecode(AbstractSensorDecode):
     def __init__(self, device_name, *args, **kwargs):
         super(OneWireTemperatureDecode, self).__init__(*args, **kwargs)
         self.device_id = device_name
-        self.device_path = "/sys/bus/w1/devices/{}/w1_slave".format(device_name)
+        self.device_path = "/sys/bus/w1/devices/{}/w1_subordinate".format(device_name)
 
     def get_reading(self):
         temp = None


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.